### PR TITLE
Error de tipeo en (n-1)

### DIFF
--- a/source/induccion.tex
+++ b/source/induccion.tex
@@ -96,8 +96,8 @@ P(n)\;:\; \sum_{i=0}^{n}i=\frac{n(n+1)}{2}
 
 \begin{demostracion}
 \begin{inducciondemo}
-\BI Si $n=0$, $\sum_{i=0}^{n}=\sum_{i=0}^{0}=0$ que es igual a $\frac{n(n-1)}{2}=0$, por lo que $P(0)$ es verdadera
-\HI Supongamos que $P(n)$ se cumple, o sea que $\sum_{i=0}^{n}i=\frac{n(n-1)}{2}$
+\BI Si $n=0$, $\sum_{i=0}^{n}=\sum_{i=0}^{0}=0$ que es igual a $\frac{n(n+1)}{2}=0$, por lo que $P(0)$ es verdadera
+\HI Supongamos que $P(n)$ se cumple, o sea que $\sum_{i=0}^{n}i=\frac{n(n+1)}{2}$
 \TI Queremos demostrar ahora que $P(n+1)$ se sigue cumpliendo, o sea, queremos demostrar que
 \[
 P(n+1)\;:\; \sum_{i=0}^{n+1}i=\frac{(n+1)((n+1)+1)}{2}


### PR DESCRIPTION
En la base e hipótesis inductiva, la fórmula debería incluir el factor (n+1), no (n-1). Independiente de si usamos inducción sobre los enteros o los naturales, el factor (n-1) induce a error.